### PR TITLE
new aggregation: mode in concretize_aggregation

### DIFF
--- a/crep/base.py
+++ b/crep/base.py
@@ -404,7 +404,6 @@ def aggregate_constant(df: pd.DataFrame,
                        id_continuous: iter,
                        ):
     """
-
     Parameters
     ----------
     df
@@ -413,7 +412,6 @@ def aggregate_constant(df: pd.DataFrame,
 
     Returns
     -------
-
     """
     data_ = df.copy(deep=True)
     dtypes = data_.dtypes
@@ -901,7 +899,10 @@ def aggregate_duplicates(
     dict_renaming = {}
     for i, items in enumerate(dict_agg.items()):
         k, v = items
-        data = df_dupl[group_by + v].groupby(by=group_by).agg(k).reset_index().drop(group_by, axis=1)
+        if k == "mode":
+            data = df_dupl[group_by + v].groupby(by=group_by).agg(lambda x: ", ".join(x.mode().to_list()[0])).reset_index().drop(group_by, axis=1)
+        else:
+            data = df_dupl[group_by + v].groupby(by=group_by).agg(k).reset_index().drop(group_by, axis=1)
         df_gr.append(data)
         colnames += [f"{k}_" + col for col in v]
         for col in v:

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -181,7 +181,6 @@ def test_homogenize(get_examples_dataframe_continuous):
     assert str(res_internal_method) == str(res_external_method), (res_internal_method, res_external_method)
     assert isinstance(res_internal_method, DataFrameContinuous), type(res_internal_method)
 
-
 def test_aggregate_on_segmentation(get_examples_dataframe_continuous):
     df, _ = get_examples_dataframe_continuous
     df_data = df.homogenize(

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -102,20 +102,38 @@ def test_concretize_aggregation():
                        "discr2": [1] * 2 + [2] * 3 + [1] * 3,
                        "cont1": [50, 100, 50, 100, 150, 50, 100, 150],
                        "cont2": [100, 150, 100, 150, 200, 100, 150, 200],
-                       "date": [2008, 2010, 2014, 2016, 2018, 2020, 2022, 2024]})
+                       "date": [2008, 2010, 2014, 2016, 2018, 2020, 2022, 2024],
+                       "objet": ["A", "B", "A", "A", "B", "B", "B", "B"]})
     df_test = tools.concretize_aggregation(
         df,
         id_discrete=["discr1", "discr2"],
         id_continuous=["cont1", "cont2"],
-        dict_agg={"min": ["date"], "max": ["date"], "sum": ["date"], "mean": ['date']}, verbose=True
+        dict_agg={"min": ["date"], "max": ["date"], "sum": ["date"], "mean": ['date'], "mode": ["objet"]}, verbose=True
     )
     assert \
         ((df_test["min_date"].to_list() == [2008, 2014, 2020])
          & (df_test["max_date"].to_list() == [2010, 2018, 2024])
          & (df_test["sum_date"].to_list() == [4018, 6048, 6066])
-         & (df_test["mean_date"].to_list() == [2009.0, 2016.0, 2022.0])), \
+         & (df_test["mean_date"].to_list() == [2009.0, 2016.0, 2022.0])
+         & (df_test["mode_objet"].to_list() == ["A, B", "A", "B"])), \
         "\n" + str(df_test)
 
+
+def test_concretize_aggregation2():
+    df = pd.DataFrame({"discr1": [1000, 1000, 1000, 1000, 1000, 2000, 2000, 2000],
+                       "discr2": [1] * 2 + [2] * 3 + [1] * 3,
+                       "cont1": [50, 100, 50, 100, 150, 50, 100, 150],
+                       "cont2": [100, 150, 100, 150, 200, 100, 150, 200],
+                       "date": [2008, 2010, 2014, 2016, 2018, 2020, 2022, 2024],
+                       "objet": ["A", "B", "A", "A", "B", "B", "B", "B"]})
+    df_test = tools.concretize_aggregation(
+        df,
+        id_discrete=["discr1", "discr2"],
+        id_continuous=["cont1", "cont2"],
+        dict_agg=None,
+        verbose=True
+    )
+    assert "mean_date" in list(df_test.columns) and "mode_objet" in list(df_test.columns), "\n" + str(df_test)
 
 def test_n_cut_finder_case1():
     df = pd.DataFrame({"discr1": [1000] * 8 + [2000] * 4,


### PR DESCRIPTION
if dict_agg is None, the columns with a dtype "number" will be aggregated with "mean" and the columns with the dtype "object" will be aggregated with "mode". If there are ex-aequo with "mode", all the most common elements are returned separated by a comma.